### PR TITLE
fix: init installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ sudo chmod 755 kubebuilder/bin/kubelet
 
 ## 3. Install Container Runtime
 ```bash
+# Remove any existing containerd installation to avoid conflicts
+sudo apt remove moby-containerd -y
 # Download and install containerd
 wget https://github.com/containerd/containerd/releases/download/v2.0.5/containerd-static-2.0.5-linux-amd64.tar.gz -O /tmp/containerd.tar.gz
 sudo tar zxf /tmp/containerd.tar.gz -C /opt/cni/
@@ -79,7 +81,7 @@ sudo cp /tmp/ca.crt /var/lib/kubelet/pki/ca.crt
 ```bash
 sudo kubebuilder/bin/kubectl config set-credentials test-user --token=1234567890
 sudo kubebuilder/bin/kubectl config set-cluster test-env --server=https://127.0.0.1:6443 --insecure-skip-tls-verify
-sudo kubebuilder/bin/kubectl config set-context test-context --cluster=test-env --user=test-user --namespace=default 
+sudo kubebuilder/bin/kubectl config set-context test-context --cluster=test-env --user=test-user --namespace=default
 sudo kubebuilder/bin/kubectl config use-context test-context
 ```
 
@@ -194,7 +196,6 @@ sudo kubebuilder/bin/kube-apiserver \
     --storage-backend=etcd3 \
     --storage-media-type=application/json \
     --v=0 \
-    --cloud-provider=external \
     --service-account-issuer=https://kubernetes.default.svc.cluster.local \
     --service-account-key-file=/tmp/sa.pub \
     --service-account-signing-key-file=/tmp/sa.key &
@@ -237,7 +238,6 @@ sudo PATH=$PATH:/opt/cni/bin:/usr/sbin kubebuilder/bin/kubelet \
     --hostname-override=$(hostname) \
     --pod-infra-container-image=registry.k8s.io/pause:3.10 \
     --node-ip=$HOST_IP \
-    --cloud-provider=external \
     --cgroup-driver=cgroupfs \
     --max-pods=4  \
     --v=1 &
@@ -254,7 +254,6 @@ sudo kubebuilder/bin/kubectl label node "$NODE_NAME" node-role.kubernetes.io/mas
 sudo PATH=$PATH:/opt/cni/bin:/usr/sbin kubebuilder/bin/kube-controller-manager \
     --kubeconfig=/var/lib/kubelet/kubeconfig \
     --leader-elect=false \
-    --cloud-provider=external \
     --service-cluster-ip-range=10.0.0.0/24 \
     --cluster-name=kubernetes \
     --root-ca-file=/var/lib/kubelet/ca.crt \
@@ -274,7 +273,7 @@ sudo kubebuilder/bin/kubectl get componentstatuses
 # Check API server health
 sudo kubebuilder/bin/kubectl get --raw='/readyz?verbose'
 
-# Create Deployment 
+# Create Deployment
 sudo  kubebuilder/bin/kubectl create deploy demo --image nginx
 
 # Check all resources

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,9 @@ download_components() {
     # Install CNI components if not present
     if [ ! -d "/opt/cni" ]; then
         sudo mkdir -p /opt/cni
-        
+        echo "Removing any existing containerd installation to avoid conflicts..."
+        sudo apt remove moby-containerd -y
+
         echo "Installing containerd..."
         wget https://github.com/containerd/containerd/releases/download/v2.0.5/containerd-static-2.0.5-linux-amd64.tar.gz -O /tmp/containerd.tar.gz
         sudo tar zxf /tmp/containerd.tar.gz -C /opt/cni/
@@ -113,7 +115,7 @@ setup_configs() {
     if ! sudo kubebuilder/bin/kubectl config current-context | grep -q "test-context"; then
         sudo kubebuilder/bin/kubectl config set-credentials test-user --token=1234567890
         sudo kubebuilder/bin/kubectl config set-cluster test-env --server=https://127.0.0.1:6443 --insecure-skip-tls-verify
-        sudo kubebuilder/bin/kubectl config set-context test-context --cluster=test-env --user=test-user --namespace=default 
+        sudo kubebuilder/bin/kubectl config set-context test-context --cluster=test-env --user=test-user --namespace=default
         sudo kubebuilder/bin/kubectl config use-context test-context
     fi
 
@@ -225,10 +227,10 @@ start() {
     fi
 
     HOST_IP=$(hostname -I | awk '{print $1}')
-    
+
     # Download components if needed
     download_components
-    
+
     # Setup configurations
     setup_configs
 
@@ -263,7 +265,6 @@ start() {
             --storage-backend=etcd3 \
             --storage-media-type=application/json \
             --v=0 \
-            --cloud-provider=external \
             --service-account-issuer=https://kubernetes.default.svc.cluster.local \
             --service-account-key-file=/tmp/sa.pub \
             --service-account-signing-key-file=/tmp/sa.key &
@@ -306,7 +307,6 @@ start() {
             --hostname-override=$(hostname) \
             --pod-infra-container-image=registry.k8s.io/pause:3.10 \
             --node-ip=$HOST_IP \
-            --cloud-provider=external \
             --cgroup-driver=cgroupfs \
             --max-pods=4  \
             --v=1 &
@@ -321,7 +321,6 @@ start() {
         sudo PATH=$PATH:/opt/cni/bin:/usr/sbin kubebuilder/bin/kube-controller-manager \
             --kubeconfig=/var/lib/kubelet/kubeconfig \
             --leader-elect=false \
-            --cloud-provider=external \
             --service-cluster-ip-range=10.0.0.0/24 \
             --cluster-name=kubernetes \
             --root-ca-file=/var/lib/kubelet/ca.crt \
@@ -377,4 +376,4 @@ case "${1:-}" in
         echo "Usage: $0 {start|stop|cleanup}"
         exit 1
         ;;
-esac 
+esac


### PR DESCRIPTION
- remove `moby-containerd` to avoid conflicts with our own containerd
- remove `--cloud-provider=external` for all components, otherwise kubelet node is going to be marked with `node.cloudprovider.kubernetes.io/uninitialized` taint as it awaits for second initialization from cloud provide, but we have none. This taint prevent any workloads be scheduled on this node.