### PR TITLE
feat: lab 01.10 entry level

### DIFF
--- a/labs/README.md
+++ b/labs/README.md
@@ -1,0 +1,18 @@
+## LAB 01.10
+
+### Entry Level
+
+Using static pods for cluster bootstaping lead to problem that limit of `--max-pods=4` of kubelet application has been reached. To fix this we need to restart kubelet with suitable `--max-pods` value, eg 10.
+```bash
+sudo PATH=$PATH:/opt/cni/bin:/usr/sbin kubebuilder/bin/kubelet \
+    --kubeconfig=/var/lib/kubelet/kubeconfig \
+    --config=/var/lib/kubelet/config.yaml \
+    --root-dir=/var/lib/kubelet \
+    --cert-dir=/var/lib/kubelet/pki \
+    --hostname-override=$(hostname) \
+    --pod-infra-container-image=registry.k8s.io/pause:3.10 \
+    --node-ip=$HOST_IP \
+    --cgroup-driver=cgroupfs \
+    --max-pods=10  \
+    --v=1 &
+```

--- a/manifests/etcd.yaml
+++ b/manifests/etcd.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+    - name: etcd
+      image: k8s.gcr.io/etcd:v3.5.13
+      command:
+        - etcd
+      args:
+        - --advertise-client-urls=http://127.0.0.1:2379
+        - --listen-client-urls=http://0.0.0.0:2379
+        - --data-dir=./etcd
+        - --listen-peer-urls=http://0.0.0.0:2380
+        - --initial-cluster=default=http://127.0.0.1:2380
+        - --initial-advertise-peer-urls=http://127.0.0.1:2380
+        - --initial-cluster-state=new
+        - --initial-cluster-token=test-token

--- a/manifests/kube-apiserver.yaml
+++ b/manifests/kube-apiserver.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+    - name: kube-apiserver
+      image: registry.k8s.io/kube-apiserver:v1.30.0
+      command:
+        - kube-apiserver
+      args:
+        - --etcd-servers=http://127.0.0.1:2379
+        - --service-cluster-ip-range=10.0.0.0/24
+        - --bind-address=0.0.0.0
+        - --secure-port=6443
+        - --advertise-address=127.0.0.1
+        - --authorization-mode=AlwaysAllow
+        - --token-auth-file=/tmp/token.csv
+        - --enable-priority-and-fairness=false
+        - --allow-privileged=true
+        - --profiling=false
+        - --storage-backend=etcd3
+        - --storage-media-type=application/json
+        - --v=0
+        - --service-account-issuer=https://kubernetes.default.svc.cluster.local
+        - --service-account-key-file=/tmp/sa.pub
+        - --service-account-signing-key-file=/tmp/sa.key
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+  volumes:
+  - name: tmp
+    hostPath:
+      path: /tmp

--- a/manifests/kube-controller-manager.yaml
+++ b/manifests/kube-controller-manager.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+    - name: kube-controller-manager
+      image: registry.k8s.io/kube-controller-manager:v1.30.0
+      command:
+        - kube-controller-manager
+      args:
+        - --kubeconfig=/root/.kube/config
+        - --leader-elect=false
+        - --service-cluster-ip-range=10.0.0.0/24
+        - --cluster-name=kubernetes
+        - --root-ca-file=/tmp/ca.crt
+        - --service-account-private-key-file=/tmp/sa.key
+        - --use-service-account-credentials=true
+        - --v=2
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: config
+          mountPath: /root/.kube/
+  volumes:
+  - name: tmp
+    hostPath:
+      path: /tmp
+  - name: config
+    hostPath:
+      path: /root/.kube

--- a/manifests/kube-scheduler.yaml
+++ b/manifests/kube-scheduler.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+spec:
+  hostNetwork: true
+  containers:
+    - name: kube-scheduler
+      image: registry.k8s.io/kube-scheduler:v1.30.0
+      command:
+        - kube-scheduler
+      args:
+        - --kubeconfig=/root/.kube/config
+        - --leader-elect=false
+        - --v=2
+        - --bind-address=0.0.0.0
+      volumeMounts:
+        - name: config
+          mountPath: /root/.kube/
+  volumes:
+  - name: config
+    hostPath:
+      path: /root/.kube


### PR DESCRIPTION
Entry level solution:
- using static pods for cluster bootstaping lead to problem that limit of `--max-pods=4` of kubelet application has been reached. To fix this we need to restart kubelet with suitable `--max-pods` value, eg 10.